### PR TITLE
feat: Implement default card selection and persistence

### DIFF
--- a/packages/card_hub/lib/src/card_hub.dart
+++ b/packages/card_hub/lib/src/card_hub.dart
@@ -2,8 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-
-
 import 'card_hub_style_data.dart';
 import 'models/card_hub_model.dart';
 import 'presentation/components/card_hub_component.dart';
@@ -12,9 +10,6 @@ import 'utils/card_configs.dart';
 import 'utils/color_extractor.dart';
 import 'utils/enumerations.dart';
 import 'utils/shared_preferences_facade.dart';
-import 'utils/styles/styles.dart';
-
-
 
 /// A widget that displays a collection of cards with motion effects, offering a
 /// visually engaging way to present a list of [CardHubModel] items.
@@ -30,6 +25,7 @@ class CardHub extends HookWidget {
     required this.items,
     this.cardHubStyleData,
     this.onRemoveCard,
+    this.loadingWidget,
   });
 
   /// The list of card models to be displayed.
@@ -45,57 +41,72 @@ class CardHub extends HookWidget {
   /// An optional callback function that is triggered when a card is removed.
   final void Function()? onRemoveCard;
 
+  /// An optional widget to display while the cards are being loaded.
+  final Widget? loadingWidget;
+
   @override
   Widget build(BuildContext context) {
     final selectedCardIndexNotifier = useValueNotifier<int?>(null);
     final selectedCardIndex = useValueListenable(selectedCardIndexNotifier);
-    // --- NEW STATE MANAGEMENT ---
-    // Holds the reordered list of cards, with the default card at the top.
-    final reorderedItems = useState<List<CardHubModel>>([]);
+
     // Holds the unique ID of the default card, loaded from local storage.
     final defaultCardId = useState<String?>(null);
     // State for color palettes remains the same.
     // State now holds a map of asset paths to a List<Color> palette.
     final brandingPalettes = useState<Map<String, List<Color>>>({});
     final isLoading = useState<bool>(true);
+    void unSelectCard() {
+      selectedCardIndexNotifier.value = null;
+    }
 
     useEffect(() {
       Future<void> initialize() async {
         isLoading.value = true;
-        await SharedPreferencesFacade.init();
-        // 1. Fetch the default card ID from local storage
-        final savedDefaultId =
-            SharedPreferencesFacade.instance.restoreData<String>(SharedPreferencesFacade.defaultCardIdKey);
-        defaultCardId.value = savedDefaultId;
 
+        // 1. Fetch the default card ID from local storage
+        final savedDefaultId = (await SharedPreferencesFacade.instance)
+            .restoreData<String>(SharedPreferencesFacade.defaultCardIdKey);
+        defaultCardId.value = savedDefaultId;
+        selectedCardIndexNotifier.value =
+            items.indexWhere((item) => item.id == savedDefaultId);
         // 2. Reorder the initial list based on the default card ID
         final List<CardHubModel> sortedList = List.from(items);
         if (savedDefaultId != null) {
-          final int defaultIndex = sortedList.indexWhere((item) => item.id == savedDefaultId);
+          final int defaultIndex =
+              sortedList.indexWhere((item) => item.id == savedDefaultId);
           if (defaultIndex != -1) {
             final defaultItem = sortedList.removeAt(defaultIndex);
             sortedList.insert(0, defaultItem);
           }
+        } else {
+          unSelectCard();
         }
-        reorderedItems.value = sortedList;
+        if (sortedList.every(
+            (item) => item.logoAssetPath != null && item.cardColor == null)) {
+          assert(
+              items.every((item) =>
+                  item.logoAssetPath != null && item.cardColor == null),
+              'if CardHub cardColor is null then logoAssetPath must not be null');
+          // 3. Generate color palettes (same as before, but uses the original items list)
+          final uniqueLogoPaths =
+              items.map((item) => item.logoAssetPath).toSet();
+          final processingFutures = uniqueLogoPaths.map((path) async {
+            try {
+              final byteData = await rootBundle.load(path!);
+              final palette =
+                  await compute(decodeAndExtractCleanPalette, byteData);
+              return MapEntry(path, palette);
+            } catch (e) {
+              debugPrint('Could not process logo $path: $e');
+              return null;
+            }
+          }).toList();
 
-        // 3. Generate color palettes (same as before, but uses the original items list)
-        final uniqueLogoPaths = items.map((item) => item.logoAssetPath).toSet();
-        final processingFutures = uniqueLogoPaths.map((path) async {
-          try {
-            final byteData = await rootBundle.load(path);
-            final palette = await compute(decodeAndExtractCleanPalette, byteData);
-            return MapEntry(path, palette);
-          } catch (e) {
-            debugPrint('Could not process logo $path: $e');
-            return null;
-          }
-        }).toList();
-
-        final results = await Future.wait(processingFutures);
-        final newPalettes = Map.fromEntries(results.whereType<MapEntry<String, List<Color>>>());
-        brandingPalettes.value = newPalettes;
-
+          final results = await Future.wait(processingFutures);
+          final newPalettes = Map.fromEntries(
+              results.whereType<MapEntry<String, List<Color>>>());
+          brandingPalettes.value = newPalettes;
+        }
         isLoading.value = false;
       }
 
@@ -105,111 +116,81 @@ class CardHub extends HookWidget {
       return null;
     }, [items]);
 
-    void unSelectCard() {
-      selectedCardIndexNotifier.value = null;
-    }
-
     // --- NEW: Function to set a card as default ---
     Future<void> setDefaultCard(String cardId) async {
       // 1. Save to local storage
-      await SharedPreferencesFacade.instance.saveData(
+      await (await SharedPreferencesFacade.instance).saveData(
         key: SharedPreferencesFacade.defaultCardIdKey,
         value: cardId,
       );
 
       // 2. Update the state to reflect the change immediately
       defaultCardId.value = cardId;
-
-      // 3. Reorder the list in the current state
-      final currentList = List<CardHubModel>.from(reorderedItems.value);
-      final int newDefaultIndex = currentList.indexWhere((item) => item.id == cardId);
-      if (newDefaultIndex != -1) {
-        final newDefaultItem = currentList.removeAt(newDefaultIndex);
-        currentList.insert(0, newDefaultItem);
-        reorderedItems.value = currentList;
-      }
-
-      // 4. Collapse the cards to show the new order
-      unSelectCard();
     }
 
     if (isLoading.value) {
-      return const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
-      );
+      return loadingWidget ?? const Center(child: CircularProgressIndicator());
     }
 
-    return Scaffold(
-      appBar: AppBar(),
-      body: reorderedItems.value.isEmpty
-          ? Center(
-              child: Padding(
-                padding: const EdgeInsets.all(8),
-                child: Text(
-                  'No Cards',
-                  textAlign: TextAlign.center,
-                  style: TextStyles.f18SemiBold(context),
+    return SingleChildScrollView(
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          AnimatedContainer(
+            duration: CardConfigs.kAnimationDuration,
+            height: CardHubLayoutHelper.totalCardsHeight(
+              selectedCardIndex: selectedCardIndex,
+              totalCard: items.length,
+            ),
+            width: double.infinity,
+          ),
+          for (int i = 0; i < items.length; i++)
+            AnimatedPositioned(
+              top: CardHubLayoutHelper.cardPositioned(
+                selectedCardIndex: selectedCardIndex,
+                index: i,
+                isSelected: i == selectedCardIndex,
+              ),
+              duration: CardConfigs.kAnimationDuration,
+              child: AnimatedScale(
+                scale: CardHubLayoutHelper.unSelectedCardsScale(
+                  selectedCardIndex: selectedCardIndex,
+                  index: i,
+                  length: items.length,
+                  isSelected: i == selectedCardIndex,
+                ),
+                duration: CardConfigs.kAnimationDuration,
+                child: GestureDetector(
+                  onTap: () {
+                    setDefaultCard(items[i].id);
+                    selectedCardIndexNotifier.value = i;
+                    items[i].onCardTap?.call(items[i]);
+                  },
+                  child: CardHubComponent(
+                    isSelected: i == selectedCardIndex,
+                    // --- PASS UPDATED PROPS ---
+                    isDefault: items[i].id == defaultCardId.value,
+                    onRemoveCard: onRemoveCard,
+
+                    card: items[i],
+                    brandingPalette:
+                        brandingPalettes.value[items[i].logoAssetPath],
+                    visaMasterCardType: CardType.values.firstWhere(
+                      (element) => element.name == items[i].type.name,
+                    ),
+                  ),
                 ),
               ),
-            )
-          : SingleChildScrollView(
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  AnimatedContainer(
-                    duration: CardConfigs.kAnimationDuration,
-                    height: CardHubLayoutHelper.totalCardsHeight(
-                      selectedCardIndex: selectedCardIndex,
-                      totalCard: reorderedItems.value.length,
-                    ),
-                    width: double.infinity,
-                  ),
-                  for (int i = 0; i < reorderedItems.value.length; i++)
-                    AnimatedPositioned(
-                      top: CardHubLayoutHelper.cardPositioned(
-                        selectedCardIndex: selectedCardIndex,
-                        index: i,
-                        isSelected: i == selectedCardIndex,
-                      ),
-                      duration: CardConfigs.kAnimationDuration,
-                      child: AnimatedScale(
-                        scale: CardHubLayoutHelper.unSelectedCardsScale(
-                          selectedCardIndex: selectedCardIndex,
-                          index: i,
-                          length: reorderedItems.value.length,
-                          isSelected: i == selectedCardIndex,
-                        ),
-                        duration: CardConfigs.kAnimationDuration,
-                        child: GestureDetector(
-                          onTap: () {
-                            selectedCardIndexNotifier.value = i;
-                          },
-                          child: CardHubComponent(
-                            isSelected: i == selectedCardIndex,
-                            // --- PASS UPDATED PROPS ---
-                            isDefault: reorderedItems.value[i].id == defaultCardId.value,
-                            onSetAsDefault: () => setDefaultCard(reorderedItems.value[i].id),
-                            onRemoveCard: onRemoveCard,
-                            card: reorderedItems.value[i],
-                            brandingPalette:
-                                brandingPalettes.value[reorderedItems.value[i].logoAssetPath],
-                            visaMasterCardType: CardType.values.firstWhere(
-                              (element) => element.name == reorderedItems.value[i].type.name,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  if (selectedCardIndex != null)
-                    Positioned.fill(
-                      child: GestureDetector(
-                        onVerticalDragEnd: (_) => unSelectCard(),
-                        onVerticalDragStart: (_) => unSelectCard(),
-                      ),
-                    ),
-                ],
+            ),
+          if (selectedCardIndex != null)
+            Positioned.fill(
+              child: GestureDetector(
+                onVerticalDragEnd: (_) => unSelectCard(),
+                onVerticalDragStart: (_) => unSelectCard(),
               ),
             ),
+        ],
+      ),
     );
   }
 }

--- a/packages/card_hub/lib/src/models/card_hub_model.dart
+++ b/packages/card_hub/lib/src/models/card_hub_model.dart
@@ -1,4 +1,5 @@
 // This file is "model.dart"
+import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../utils/enumerations.dart'; 
@@ -7,35 +8,38 @@ import '../utils/enumerations.dart';
 part 'card_hub_model.freezed.dart';
 
 /// Represents a credit card model.
+
 @freezed
 class CardHubModel with _$CardHubModel {
   /// Constructs a [CardHubModel].
   const factory CardHubModel({
     /// A unique identifier for the card.
     required String id,
-
     /// A string indicating number on the card.
     required int lastFour,
-
     /// The expiration month of the credit card.
     required int expirationMonth,
-
     /// The expiration year of the credit card.
     required int expirationYear,
-
     /// A string indicating name of the card holder.
     required String cardHolderName,
-
     /// Sets type of the card. An small image is shown based on selected type
     /// of the card at bottom right corner. If this is set to null then image
     /// shown automatically based on credit card number.
     required CardType type,
-
     /// A string indicating name of the bank.
     required String bankName,
-
     /// The local asset path for the card's brand logo (e.g., 'assets/logos/netflix.png').
     /// If provided, the card will be themed based on this logo.
-    required String logoAssetPath,
+    String? logoAssetPath,
+    /// The color of the card. If provided, the card will be themed based on this color.
+    Color? cardColor,
+
+    /// Optional callback function that is triggered when a card is selected.
+    void Function(CardHubModel model)? onCardTap,
   }) = _CardHubModel;
+
+  // Add this method to your class:
+  @Assert('!(logoAssetPath != null && cardColor != null)', 'Cannot provide both logoAssetPath and cardColor')
+  const CardHubModel._();
 }

--- a/packages/card_hub/lib/src/models/card_hub_model.freezed.dart
+++ b/packages/card_hub/lib/src/models/card_hub_model.freezed.dart
@@ -41,7 +41,14 @@ mixin _$CardHubModel {
 
   /// The local asset path for the card's brand logo (e.g., 'assets/logos/netflix.png').
   /// If provided, the card will be themed based on this logo.
-  String get logoAssetPath => throw _privateConstructorUsedError;
+  String? get logoAssetPath => throw _privateConstructorUsedError;
+
+  /// The color of the card. If provided, the card will be themed based on this color.
+  Color? get cardColor => throw _privateConstructorUsedError;
+
+  /// Optional callback function that is triggered when a card is selected.
+  void Function(CardHubModel)? get onCardTap =>
+      throw _privateConstructorUsedError;
 
   /// Create a copy of CardHubModel
   /// with the given fields replaced by the non-null parameter values.
@@ -64,7 +71,9 @@ abstract class $CardHubModelCopyWith<$Res> {
       String cardHolderName,
       CardType type,
       String bankName,
-      String logoAssetPath});
+      String? logoAssetPath,
+      Color? cardColor,
+      void Function(CardHubModel)? onCardTap});
 }
 
 /// @nodoc
@@ -89,7 +98,9 @@ class _$CardHubModelCopyWithImpl<$Res, $Val extends CardHubModel>
     Object? cardHolderName = null,
     Object? type = null,
     Object? bankName = null,
-    Object? logoAssetPath = null,
+    Object? logoAssetPath = freezed,
+    Object? cardColor = freezed,
+    Object? onCardTap = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -120,10 +131,18 @@ class _$CardHubModelCopyWithImpl<$Res, $Val extends CardHubModel>
           ? _value.bankName
           : bankName // ignore: cast_nullable_to_non_nullable
               as String,
-      logoAssetPath: null == logoAssetPath
+      logoAssetPath: freezed == logoAssetPath
           ? _value.logoAssetPath
           : logoAssetPath // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
+      cardColor: freezed == cardColor
+          ? _value.cardColor
+          : cardColor // ignore: cast_nullable_to_non_nullable
+              as Color?,
+      onCardTap: freezed == onCardTap
+          ? _value.onCardTap
+          : onCardTap // ignore: cast_nullable_to_non_nullable
+              as void Function(CardHubModel)?,
     ) as $Val);
   }
 }
@@ -144,7 +163,9 @@ abstract class _$$CardHubModelImplCopyWith<$Res>
       String cardHolderName,
       CardType type,
       String bankName,
-      String logoAssetPath});
+      String? logoAssetPath,
+      Color? cardColor,
+      void Function(CardHubModel)? onCardTap});
 }
 
 /// @nodoc
@@ -167,7 +188,9 @@ class __$$CardHubModelImplCopyWithImpl<$Res>
     Object? cardHolderName = null,
     Object? type = null,
     Object? bankName = null,
-    Object? logoAssetPath = null,
+    Object? logoAssetPath = freezed,
+    Object? cardColor = freezed,
+    Object? onCardTap = freezed,
   }) {
     return _then(_$CardHubModelImpl(
       id: null == id
@@ -198,17 +221,25 @@ class __$$CardHubModelImplCopyWithImpl<$Res>
           ? _value.bankName
           : bankName // ignore: cast_nullable_to_non_nullable
               as String,
-      logoAssetPath: null == logoAssetPath
+      logoAssetPath: freezed == logoAssetPath
           ? _value.logoAssetPath
           : logoAssetPath // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
+      cardColor: freezed == cardColor
+          ? _value.cardColor
+          : cardColor // ignore: cast_nullable_to_non_nullable
+              as Color?,
+      onCardTap: freezed == onCardTap
+          ? _value.onCardTap
+          : onCardTap // ignore: cast_nullable_to_non_nullable
+              as void Function(CardHubModel)?,
     ));
   }
 }
 
 /// @nodoc
 
-class _$CardHubModelImpl implements _CardHubModel {
+class _$CardHubModelImpl extends _CardHubModel {
   const _$CardHubModelImpl(
       {required this.id,
       required this.lastFour,
@@ -217,7 +248,10 @@ class _$CardHubModelImpl implements _CardHubModel {
       required this.cardHolderName,
       required this.type,
       required this.bankName,
-      required this.logoAssetPath});
+      this.logoAssetPath,
+      this.cardColor,
+      this.onCardTap})
+      : super._();
 
   /// A unique identifier for the card.
   @override
@@ -252,11 +286,19 @@ class _$CardHubModelImpl implements _CardHubModel {
   /// The local asset path for the card's brand logo (e.g., 'assets/logos/netflix.png').
   /// If provided, the card will be themed based on this logo.
   @override
-  final String logoAssetPath;
+  final String? logoAssetPath;
+
+  /// The color of the card. If provided, the card will be themed based on this color.
+  @override
+  final Color? cardColor;
+
+  /// Optional callback function that is triggered when a card is selected.
+  @override
+  final void Function(CardHubModel)? onCardTap;
 
   @override
   String toString() {
-    return 'CardHubModel(id: $id, lastFour: $lastFour, expirationMonth: $expirationMonth, expirationYear: $expirationYear, cardHolderName: $cardHolderName, type: $type, bankName: $bankName, logoAssetPath: $logoAssetPath)';
+    return 'CardHubModel(id: $id, lastFour: $lastFour, expirationMonth: $expirationMonth, expirationYear: $expirationYear, cardHolderName: $cardHolderName, type: $type, bankName: $bankName, logoAssetPath: $logoAssetPath, cardColor: $cardColor, onCardTap: $onCardTap)';
   }
 
   @override
@@ -277,12 +319,26 @@ class _$CardHubModelImpl implements _CardHubModel {
             (identical(other.bankName, bankName) ||
                 other.bankName == bankName) &&
             (identical(other.logoAssetPath, logoAssetPath) ||
-                other.logoAssetPath == logoAssetPath));
+                other.logoAssetPath == logoAssetPath) &&
+            (identical(other.cardColor, cardColor) ||
+                other.cardColor == cardColor) &&
+            (identical(other.onCardTap, onCardTap) ||
+                other.onCardTap == onCardTap));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, id, lastFour, expirationMonth,
-      expirationYear, cardHolderName, type, bankName, logoAssetPath);
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      lastFour,
+      expirationMonth,
+      expirationYear,
+      cardHolderName,
+      type,
+      bankName,
+      logoAssetPath,
+      cardColor,
+      onCardTap);
 
   /// Create a copy of CardHubModel
   /// with the given fields replaced by the non-null parameter values.
@@ -293,7 +349,7 @@ class _$CardHubModelImpl implements _CardHubModel {
       __$$CardHubModelImplCopyWithImpl<_$CardHubModelImpl>(this, _$identity);
 }
 
-abstract class _CardHubModel implements CardHubModel {
+abstract class _CardHubModel extends CardHubModel {
   const factory _CardHubModel(
       {required final String id,
       required final int lastFour,
@@ -302,7 +358,10 @@ abstract class _CardHubModel implements CardHubModel {
       required final String cardHolderName,
       required final CardType type,
       required final String bankName,
-      required final String logoAssetPath}) = _$CardHubModelImpl;
+      final String? logoAssetPath,
+      final Color? cardColor,
+      final void Function(CardHubModel)? onCardTap}) = _$CardHubModelImpl;
+  const _CardHubModel._() : super._();
 
   /// A unique identifier for the card.
   @override
@@ -337,7 +396,15 @@ abstract class _CardHubModel implements CardHubModel {
   /// The local asset path for the card's brand logo (e.g., 'assets/logos/netflix.png').
   /// If provided, the card will be themed based on this logo.
   @override
-  String get logoAssetPath;
+  String? get logoAssetPath;
+
+  /// The color of the card. If provided, the card will be themed based on this color.
+  @override
+  Color? get cardColor;
+
+  /// Optional callback function that is triggered when a card is selected.
+  @override
+  void Function(CardHubModel)? get onCardTap;
 
   /// Create a copy of CardHubModel
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/card_hub/lib/src/presentation/components/card_hub_component.dart
+++ b/packages/card_hub/lib/src/presentation/components/card_hub_component.dart
@@ -19,7 +19,7 @@ class CardHubComponent extends StatelessWidget {
     required this.visaMasterCardType,
     required this.isSelected,
     required this.isDefault, // New: To show a "Default" badge
-    required this.onSetAsDefault, // New: Callback to set this card as default
+   
     this.onRemoveCard,
     this.cardHubStyleData,
     this.brandingPalette,
@@ -51,14 +51,11 @@ class CardHubComponent extends StatelessWidget {
   /// If `true`, a "Default" badge is displayed on the card.
   final bool isDefault;
 
-  /// A callback function that is triggered when the default icon is tapped.
-  ///
-  /// The default icon is only visible when [isDefault] is `true`.
-  final void Function()? onSetAsDefault;
-
   /// A Material 3 ColorScheme generated from the card's logo.
   /// If provided, it overrides the default gradient.
-  final List<Color>? brandingPalette; // 👈 Define property
+  final List<Color>? brandingPalette;
+
+
 
   /// Builds the widget tree for this component.
   @override
@@ -69,8 +66,10 @@ class CardHubComponent extends StatelessWidget {
     // Determine background and content color from the palette
     if (brandingPalette != null && brandingPalette!.isNotEmpty) {
       // Use the first color in the palette to determine text/icon contrast
-      final brightness = ThemeData.estimateBrightnessForColor(brandingPalette![0]);
-      contentColor = brightness == Brightness.dark ? Colors.white : Colors.black87;
+      final brightness =
+          ThemeData.estimateBrightnessForColor(brandingPalette![0]);
+      contentColor =
+          brightness == Brightness.dark ? Colors.white : Colors.black87;
 
       if (brandingPalette!.length > 1) {
         // Create a gradient from the palette
@@ -83,31 +82,40 @@ class CardHubComponent extends StatelessWidget {
     }
 
     final TextStyle brandedTextStyle =
-        TextStyles.defaultCreditCardStyle(context).copyWith(color: contentColor);
+        TextStyles.defaultCreditCardStyle(context)
+            .copyWith(color: contentColor);
 
     return Stack(
       children: [
         Container(
-          decoration: BoxDecoration(
-            // If a brandingScheme exists, use it. Otherwise, fall back to the gradient.
-            // Use solid color if only one color in palette, otherwise use the new gradient
-            color: (brandingPalette?.length == 1) ? brandingPalette![0] : null,
-            gradient:
-                backgroundGradient ?? cardHubStyleData?.gradient ?? visaMasterCardType.gradient,
-            borderRadius: const BorderRadius.all(Radius.circular(15)),
-            image: DecorationImage(
-              image: AssetImage(card.logoAssetPath),
-              fit: BoxFit.fill,
-              filterQuality: FilterQuality.high,
-              opacity: 0.2,
-            ),
-          ),
-          width: cardHubStyleData?.width ?? MediaQuery.sizeOf(context).width * 0.9,
+          decoration: card.logoAssetPath != null
+              ? BoxDecoration(
+                  // If a brandingScheme exists, use it. Otherwise, fall back to the gradient.
+                  // Use solid color if only one color in palette, otherwise use the new gradient
+                  color: (brandingPalette?.length == 1)
+                      ? brandingPalette![0]
+                      : null,
+                  gradient: backgroundGradient ??
+                      cardHubStyleData?.gradient ??
+                      visaMasterCardType.gradient,
+                  borderRadius: const BorderRadius.all(Radius.circular(15)),
+                  image: DecorationImage(
+                    image: AssetImage(card.logoAssetPath!),
+                    fit: BoxFit.fill,
+                    filterQuality: FilterQuality.high,
+                    opacity: 0.2,
+                  ))
+              : BoxDecoration(
+                  borderRadius: const BorderRadius.all(Radius.circular(15)),
+                  color: card.cardColor,
+                ),
+          width:
+              cardHubStyleData?.width ?? MediaQuery.sizeOf(context).width * 0.8,
           margin: const EdgeInsets.symmetric(
             horizontal: Sizes.paddingH20,
           ).copyWith(top: Sizes.paddingV10),
-          padding:
-              cardHubStyleData?.padding ?? const EdgeInsets.only(left: 16, right: 16, bottom: 22),
+          padding: cardHubStyleData?.padding ??
+              const EdgeInsets.only(left: 16, right: 16, bottom: 22),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -116,7 +124,7 @@ class CardHubComponent extends StatelessWidget {
                 image: cardHubStyleData?.logoImage ?? visaMasterCardType.image,
               ),
               const SizedBox(height: Sizes.marginV16),
-              Text(card.bankName , style: brandedTextStyle),
+              Text(card.bankName, style: brandedTextStyle),
               const SizedBox(height: Sizes.marginV16),
               Text(
                 '${AppConstants.twelveX} ${card.lastFour}',
@@ -144,32 +152,6 @@ class CardHubComponent extends StatelessWidget {
             ],
           ),
         ),
-            // Show "Set as Default" button only when the card is selected
-        // and it is NOT already the default card.
-        if (!isDefault && isSelected)
-          Positioned(
-            right: 10,
-            child: InkWell(
-              onTap: onSetAsDefault,
-              child: const CircleAvatar(
-                backgroundColor: Colors.red,
-                radius: Sizes.cardR16,
-                child: Icon(Icons.done, color: Colors.white),
-              ),
-            ),
-          ),
-        // Show "Default" chip if it's the default card
-        if (isDefault)
-          const Positioned(
-            right: 10,
-            child: CircleAvatar(
-              backgroundColor: Colors.green,
-              radius: Sizes.cardR16,
-              child: Icon(Icons.star, color: Colors.white),
-            ),
-          ),
-
-    
       ],
     );
   }

--- a/packages/card_hub/lib/src/utils/shared_preferences_facade.dart
+++ b/packages/card_hub/lib/src/utils/shared_preferences_facade.dart
@@ -28,28 +28,17 @@ class SharedPreferencesFacade {
 
   /// The key used to store the default card ID in shared preferences.
   static String defaultCardIdKey = 'defaultCardId';
-  static late final SharedPreferencesFacade _instance;
+  static SharedPreferencesFacade ?_instance;
   final SharedPreferences _sharedPrefs;
 
-  /// Initializes the singleton instance of [SharedPreferencesFacade].
-  ///
-  /// This must be called once in the app's entry point (e.g., `main`) before
-  /// accessing the [instance].
-  static Future<void> init() async {
-    final prefs = await SharedPreferences.getInstance();
-    _instance = SharedPreferencesFacade._(prefs);
-  }
 
-  /// Provides global access to the singleton [SharedPreferencesFacade] instance.
-  static SharedPreferencesFacade get instance {
-    try {
-      return _instance;
-    } catch (_) {
-      throw Exception(
-        'SharedPreferencesFacade.instance was accessed before initialization.\n'
-        'Make sure you called await SharedPreferencesFacade.init() in main().',
-      );
-    }
+
+ /// Lazily gets or creates the singleton instance.
+  static Future<SharedPreferencesFacade> get instance async {
+    _instance ??= SharedPreferencesFacade._(
+      await SharedPreferences.getInstance(),
+    );
+    return _instance!;
   }
 
   /// Saves a value to shared preferences with the specified [key].


### PR DESCRIPTION
This commit introduces the functionality for users to select and persist a default card.

Changes include:
- A [SharedPreferencesFacade](cci:2://file:///Users/mohamedabouassi/Desktop/projects/card_demo/card_hub/packages/card_hub/lib/src/utils/shared_preferences_facade.dart:25:0-93:1) to manage data persistence using `shared_preferences`.
- A [CardHubModel](cci:2://file:///Users/mohamedabouassi/Desktop/projects/card_demo/card_hub/packages/card_hub/lib/src/models/card_hub_model.dart:11:0-44:1) to represent card data, with `freezed` for immutability.
- A [CardHubComponent](cci:2://file:///Users/mohamedabouassi/Desktop/projects/card_demo/card_hub/packages/card_hub/lib/src/presentation/components/card_hub_component.dart:14:0-157:1) to display card information.
- Integration of the new components and services into the main `card_hub` package.

This feature allows the application to remember the user's chosen default card across sessions, improving the user experience.